### PR TITLE
Fix installation instructions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -13,7 +13,7 @@ Currently supports PNG, JPG, and GIF.
 
 ## Installation
 ```
-sudo curl https://raw.githubusercontent.com/evyatarmeged/stegextract/master/stegextract > /usr/local/bin/stegextract
+sudo sh -c 'curl https://raw.githubusercontent.com/evyatarmeged/stegextract/master/stegextract > /usr/local/bin/stegextract'
 sudo chmod +x /usr/local/bin/stegextract
 ```
 


### PR DESCRIPTION
The original instructions didn't run the shell as sudo which caused the redirection to not work due to permission issues. 
